### PR TITLE
Add support for newer SFA OS

### DIFF
--- a/src/DDNTool.py
+++ b/src/DDNTool.py
@@ -45,6 +45,15 @@ except ImportError:
     # then we'll throw a runtime exception down in the config parsing section.
     pass
 
+import ssl
+try:
+    _create_unverified_https_context = ssl._create_unverified_context
+except AttributeError:
+    # Old Python doesn't check https by default
+    pass
+else:
+    # skip ssl verifications
+    ssl._create_default_https_context = _create_unverified_https_context
 
 from DDNToolSupport import bracket_expand, bracket_aware_split
 

--- a/src/DDNToolSupport/SFAClientUtils/SFAClient.py
+++ b/src/DDNToolSupport/SFAClientUtils/SFAClient.py
@@ -379,7 +379,7 @@ class SFAClient():
         virt_disks = SFAVirtualDisk.getAll()  
         for disk in virt_disks:
             # Save the PoolState field in the dictionary
-            self._storage_pool_states[self._vd_to_lun[disk.Index]] = pools_d[disk.PoolIndex].PoolState
+            self._storage_pool_states[self._vd_to_lun[disk.Index]] = pools_d[disk.PoolIndex].PoolState or 0
         
 
         
@@ -711,6 +711,11 @@ class SFAClient():
         expected_lun_latency_labels[3] = \
             ['<=4ms', '<=8ms', '<=16ms', '<=32ms', '<=64ms', '<=128ms',
              '<=256ms', '<=512ms', '<=1s', '<=2s', '<=4s', '>4s']
+
+        expected_lun_latency_labels[11] = \
+            ['<=4ms', '<=8ms', '<=16ms', '<=32ms', '<=64ms', '<=128ms',
+             '<=256ms', '<=512ms', '<=1s', '<=2s', '<=4s', '>4s']
+
         
 #        expected_dd_latency_labels = ['Latency Counts <=4ms', 'Latency Counts <=8ms',
 #                'Latency Counts <=16ms', 'Latency Counts <=32ms', 'Latency Counts <=64ms',


### PR DESCRIPTION
Ensuring older version of python semantics are kept regardless of host version.

Newer versions of SFA OS don't appear to set a PoolState when they are healthy.