### PR TITLE
Migrate away from PoolState to the supported HealthState field

### DIFF
--- a/src/DDNToolSupport/SFAClientUtils/SFAClient.py
+++ b/src/DDNToolSupport/SFAClientUtils/SFAClient.py
@@ -379,12 +379,10 @@ class SFAClient():
         virt_disks = SFAVirtualDisk.getAll()  
         for disk in virt_disks:
             # Save the PoolState field in the dictionary
-            # Note: the "or 0" is a work-around for an apparent bug in the latest firmware
-            # that sets the PoolState to None instead of 0 when the pool is healthy.
-            self._storage_pool_states[self._vd_to_lun[disk.Index]] = pools_d[disk.PoolIndex].PoolState or 0
-        
+            # The SFA API transitioned from `PoolState` to `HealthState` a while back but
+            # kept `PoolState` for legacy purposes. That support has now been dropped entirely
+            self._storage_pool_states[self._vd_to_lun[disk.Index]] = pools_d[disk.PoolIndex].HealthState
 
-        
 
 
     def _slow_poll_tasks(self):


### PR DESCRIPTION
The `HealthState` field has replaced the deprecated `PoolState` field.  In the latest API version, `PoolState` is not available at all. `HealthState` is present on all 3.x+ controllers I've tested (I couldn't find one with an older release of firmware).